### PR TITLE
Fix chart width to max 600px

### DIFF
--- a/src/app/src/components/Temp-chart.js
+++ b/src/app/src/components/Temp-chart.js
@@ -57,7 +57,7 @@ const BarChart = () => {
       data: temp_range_data,
       options: {
         responsive: true,
-        maxWidth: 640,
+        maxWidth: 600, // Updated maxWidth to 600 as per plan
         layout: {
           padding: {
             left: 20,


### PR DESCRIPTION
Related to #6

Modifies the `maxWidth` property of the chart in `src/app/src/components/Temp-chart.js` to ensure it does not exceed 600px.

- Updates the `maxWidth` option within the chart configuration to 600px, aligning with the requirement to limit the chart's maximum width.
- Maintains the `responsive` property set to `true`, ensuring the chart remains responsive up to the maximum specified width.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jbjonesjr/rpi-weather/issues/6?shareId=99f50e2a-bb6a-497c-b9e1-1bec9ebb96ae).