### PR TITLE
Fix import issue in rtl-publish tests

### DIFF
--- a/src/rtl-publish/tests/db_mocks.js
+++ b/src/rtl-publish/tests/db_mocks.js
@@ -1,5 +1,5 @@
 // Mocks for database interactions in rtl_process.js
-const dbMocks = {
+export const dbMocks = {
   // Mock for client.connect
   connect: jest.fn().mockResolvedValue(),
 
@@ -31,5 +31,3 @@ const dbMocks = {
     client: require('../tests/db_mocks').dbMocks
   }));
 */
-
-module.exports = dbMocks;


### PR DESCRIPTION
Updates the export syntax in `src/rtl-publish/tests/db_mocks.js` to resolve module import error during testing.
- Changes `module.exports` to ES module `export` syntax for `dbMocks`.
- Ensures compatibility with ES module import syntax used in `tests.js`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jbjonesjr/rpi-weather?shareId=6a2bd2db-f40e-4231-8604-0b238bec624f).