### PR TITLE
Update the version of node in this repo to at least 20.5

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,6 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
 {
 	"name": "Node.js & TypeScript",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-20",
 	"features": {
 		"ghcr.io/devcontainers-contrib/features/heroku-cli:1": {}
 	},
@@ -19,19 +16,4 @@
 			]
 		}
 	}
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "working on turning a raspberry pi into an always on, internet connected weather station",
   "main": "index.js",
   "engines": {
-    "node": "18.x"
+    "node": ">=20.5.0"
   },
   "scripts": {
     "install": "npm run install:services && npm run install:client && npm run install:server",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "engines": {
-    "node": "18.x"
+    "node": ">=20.5.0"
   },
   "browserslist": {
     "production": [

--- a/src/rtl-publish/package.json
+++ b/src/rtl-publish/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/jbjonesjr/rpi-weather#readme",
   "type": "module",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.5.0"
   },
   "dependencies": {
     "@rauschma/stringio": "^1.4.0",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -23,5 +23,8 @@
     "express": "^4.18.1",
     "pg": "^8.7.3",
     "services": "file:../services"
+  },
+  "engines": {
+    "node": ">=20.5.0"
   }
 }

--- a/src/services/package.json
+++ b/src/services/package.json
@@ -20,5 +20,8 @@
   "homepage": "https://github.com/jbjonesjr/rpi-weather#readme",
   "dependencies": {
     "pg": "^8.7.3"
+  },
+  "engines": {
+    "node": ">=20.5.0"
   }
 }


### PR DESCRIPTION
Update the Node.js version to at least 20.5 in the repository.

* **package.json**: Update the `node` version in the `engines` field to `>=20.5.0`.
* **src/app/package.json**: Update the `node` version in the `engines` field to `>=20.5.0`.
* **src/rtl-publish/package.json**: Update the `node` version in the `engines` field to `>=20.5.0`.
* **src/server/package.json**: Add the `engines` field with `node` version `>=20.5.0`.
* **src/services/package.json**: Add the `engines` field with `node` version `>=20.5.0`.
* **.devcontainer/devcontainer.json**: Update the Docker image to `mcr.microsoft.com/devcontainers/typescript-node:0-20`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jbjonesjr/rpi-weather?shareId=033c568a-0cf3-4c46-83b1-a10023100a45).